### PR TITLE
Tracks bridge attempts with dedicated mappings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -65,7 +65,7 @@
         "--no-warnings=ExperimentalWarning",
         "./node_modules/.bin/hardhat",
         "test",
-        "test/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.test.ts",
+        "test/xyo-chain/helpers/liquidityPoolBridgeHelpers.ts",
       ],
       "env": {
         "TS_NODE_PROJECT": "./tsconfig.json"

--- a/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/ILiquidityPoolBridge.sol
+++ b/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/ILiquidityPoolBridge.sol
@@ -10,6 +10,10 @@ interface ILiquidityPoolBridge {
     error BridgeAmountExceedsMax(uint256 amount, uint256 maxAllowed);
     /// @notice Thrown when bridged amount provided is zero
     error BridgeAmountZero();
+    /// @notice Thrown when a bridge to remote already exists for the given ID
+    error BridgesToRemoteAlreadyExists(uint256 id);
+    /// @notice Thrown when a bridge from remote already exists for the given ID
+    error BridgesFromRemoteAlreadyExists(bytes32 id);
 
     /// @notice Emitted when a bridge to another chain is requested
     event BridgedToRemote(

--- a/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/ILiquidityPoolBridge.sol
+++ b/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/ILiquidityPoolBridge.sol
@@ -59,9 +59,11 @@ interface ILiquidityPoolBridge {
     /// @param srcAddress The address initiating the bridge
     /// @param destAddress The address receiving the bridged tokens
     /// @param amount The amount of tokens being bridged
+    /// @param nonce The unique identifier for the bridge transaction
     function bridgeFromRemote(
         address srcAddress,
         address destAddress,
-        uint256 amount
+        uint256 amount,
+        bytes32 nonce
     ) external;
 }

--- a/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/ILiquidityPoolBridge.sol
+++ b/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/ILiquidityPoolBridge.sol
@@ -22,7 +22,7 @@ interface ILiquidityPoolBridge {
 
     /// @notice Emitted when a bridge from another chain is completed
     event BridgedFromRemote(
-        uint256 indexed id,
+        bytes32 indexed id,
         address indexed srcAddress,
         address indexed destAddress,
         uint256 amount,

--- a/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
+++ b/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
@@ -31,6 +31,17 @@ contract LiquidityPoolBridge is
     /// @notice Source for the liquidity funds
     address public liquiditySource;
 
+    /// @notice Struct to store bridge to remote event data
+    struct BridgeToRemoteData {
+        address srcAddress;
+        address destAddress;
+        uint256 amount;
+        address destToken;
+    }
+
+    /// @notice Mapping of bridge IDs to bridging to remote event data
+    mapping(uint256 => BridgeToRemoteData) public bridgesToRemote;
+
     /// @notice Constructor for the LiquidityPoolBridge contract
     /// @param remoteChain_ The identifier for the remote chain
     /// @param token_ The address of the ERC20 representing the asset being bridged
@@ -82,8 +93,20 @@ contract LiquidityPoolBridge is
         // Transfer tokens from sender to liquidity source
         token.safeTransferFrom(msg.sender, liquiditySource, amount);
 
+        // Generate a new bridge ID
+        uint256 nextId = nextBridgeToId++;
+
+        // update mapping
+        bridgesToRemote[nextId] = BridgeToRemoteData({
+            srcAddress: msg.sender,
+            destAddress: destAddress,
+            amount: amount,
+            destToken: address(token)
+        });
+
+        // emit event
         emit BridgedToRemote(
-            nextBridgeToId++,
+            nextId,
             msg.sender,
             destAddress,
             amount,

--- a/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
+++ b/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
@@ -102,18 +102,18 @@ contract LiquidityPoolBridge is
         }
 
         // Generate a new bridge ID
-        uint256 bridgeId = nextBridgeToId++;
+        nextBridgeToId++;
 
         // Check if bridge ID already exists
-        if (bridgesToRemote[bridgeId].srcAddress != address(0)) {
-            revert BridgesToRemoteAlreadyExists(bridgeId);
+        if (bridgesToRemote[nextBridgeToId].srcAddress != address(0)) {
+            revert BridgesToRemoteAlreadyExists(nextBridgeToId);
         }
 
         // Transfer tokens from sender to liquidity source
         token.safeTransferFrom(msg.sender, liquiditySource, amount);
 
         // update mapping
-        bridgesToRemote[bridgeId] = BridgeToRemoteData({
+        bridgesToRemote[nextBridgeToId] = BridgeToRemoteData({
             srcAddress: msg.sender,
             destAddress: destAddress,
             amount: amount,
@@ -122,7 +122,7 @@ contract LiquidityPoolBridge is
 
         // emit event
         emit BridgedToRemote(
-            bridgeId,
+            nextBridgeToId,
             msg.sender,
             destAddress,
             amount,

--- a/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
+++ b/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
@@ -73,16 +73,6 @@ contract LiquidityPoolBridge is
         liquiditySource = liquiditySource_;
     }
 
-    function _incrementBridgeToId() internal returns (uint256 id) {
-        id = nextBridgeToId;
-        nextBridgeToId++;
-    }
-
-    function _incrementBridgeFromId() internal returns (uint256 id) {
-        id = nextBridgeFromId;
-        nextBridgeFromId++;
-    }
-
     /// @notice Set a new maximum bridge amount
     /// @param newMax The new maximum bridge amount
     function setMaxBridgeAmount(
@@ -112,7 +102,7 @@ contract LiquidityPoolBridge is
         }
 
         // Generate a new bridge ID
-        uint256 bridgeId = _incrementBridgeToId();
+        uint256 bridgeId = nextBridgeToId++;
 
         // Check if bridge ID already exists
         if (bridgesToRemote[bridgeId].srcAddress != address(0)) {
@@ -166,7 +156,7 @@ contract LiquidityPoolBridge is
         }
 
         // Increment bridge from remote counter
-        _incrementBridgeFromId();
+        nextBridgeFromId++;
 
         // Transfer tokens from liquidity source to destination
         token.safeTransferFrom(liquiditySource, destAddress, amount);

--- a/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
+++ b/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
@@ -42,6 +42,7 @@ contract LiquidityPoolBridge is
     /// @notice Mapping of bridge IDs to bridging to remote event data
     mapping(uint256 => BridgeToRemoteData) public bridgesToRemote;
 
+    /// @notice Struct to store bridge from remote event data
     struct BridgeFromRemoteData {
         address srcAddress;
         address destAddress;

--- a/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
+++ b/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
@@ -73,6 +73,16 @@ contract LiquidityPoolBridge is
         liquiditySource = liquiditySource_;
     }
 
+    function _incrementBridgeToId() internal returns (uint256 id) {
+        id = nextBridgeToId;
+        nextBridgeToId++;
+    }
+
+    function _incrementBridgeFromId() internal returns (uint256 id) {
+        id = nextBridgeFromId;
+        nextBridgeFromId++;
+    }
+
     /// @notice Set a new maximum bridge amount
     /// @param newMax The new maximum bridge amount
     function setMaxBridgeAmount(
@@ -102,18 +112,18 @@ contract LiquidityPoolBridge is
         }
 
         // Generate a new bridge ID
-        uint256 nextId = nextBridgeToId++;
+        uint256 bridgeId = _incrementBridgeToId();
 
         // Check if bridge ID already exists
-        if (bridgesToRemote[nextId].srcAddress != address(0)) {
-            revert BridgesToRemoteAlreadyExists(nextId);
+        if (bridgesToRemote[bridgeId].srcAddress != address(0)) {
+            revert BridgesToRemoteAlreadyExists(bridgeId);
         }
 
         // Transfer tokens from sender to liquidity source
         token.safeTransferFrom(msg.sender, liquiditySource, amount);
 
         // update mapping
-        bridgesToRemote[nextId] = BridgeToRemoteData({
+        bridgesToRemote[bridgeId] = BridgeToRemoteData({
             srcAddress: msg.sender,
             destAddress: destAddress,
             amount: amount,
@@ -122,7 +132,7 @@ contract LiquidityPoolBridge is
 
         // emit event
         emit BridgedToRemote(
-            nextId,
+            bridgeId,
             msg.sender,
             destAddress,
             amount,
@@ -156,7 +166,7 @@ contract LiquidityPoolBridge is
         }
 
         // Increment bridge from remote counter
-        nextBridgeFromId++;
+        _incrementBridgeFromId();
 
         // Transfer tokens from liquidity source to destination
         token.safeTransferFrom(liquiditySource, destAddress, amount);

--- a/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
+++ b/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
@@ -101,11 +101,16 @@ contract LiquidityPoolBridge is
             revert BridgeAmountExceedsMax(amount, maxBridgeAmount);
         }
 
-        // Transfer tokens from sender to liquidity source
-        token.safeTransferFrom(msg.sender, liquiditySource, amount);
-
         // Generate a new bridge ID
         uint256 nextId = nextBridgeToId++;
+
+        // Check if bridge ID already exists
+        if (bridgesToRemote[nextId].srcAddress != address(0)) {
+            revert BridgesToRemoteAlreadyExists(nextId);
+        }
+
+        // Transfer tokens from sender to liquidity source
+        token.safeTransferFrom(msg.sender, liquiditySource, amount);
 
         // update mapping
         bridgesToRemote[nextId] = BridgeToRemoteData({
@@ -144,6 +149,10 @@ contract LiquidityPoolBridge is
         }
         if (amount > maxBridgeAmount) {
             revert BridgeAmountExceedsMax(amount, maxBridgeAmount);
+        }
+        // Check if nonce already exists
+        if (bridgesFromRemote[nonce].srcAddress != address(0)) {
+            revert BridgesFromRemoteAlreadyExists(nonce);
         }
 
         // Increment bridge from remote counter

--- a/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
+++ b/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
@@ -128,7 +128,7 @@ contract LiquidityPoolBridge is
     /// @param srcAddress The address initiating the bridge
     /// @param destAddress The address receiving the bridged tokens
     /// @param amount The amount of tokens being bridged
-    /// @param nonce The unique identifier for the bridge transaction
+    /// @param nonce The unique identifier for the bridge transaction (i.e. transaction hash from remote chain)
     function bridgeFromRemote(
         address srcAddress,
         address destAddress,
@@ -145,6 +145,9 @@ contract LiquidityPoolBridge is
             revert BridgeAmountExceedsMax(amount, maxBridgeAmount);
         }
 
+        // Increment bridge from remote counter
+        nextBridgeFromId++;
+
         // Transfer tokens from liquidity source to destination
         token.safeTransferFrom(liquiditySource, destAddress, amount);
 
@@ -156,8 +159,9 @@ contract LiquidityPoolBridge is
             destToken: address(token)
         });
 
+        // emit event
         emit BridgedFromRemote(
-            nextBridgeFromId++,
+            nonce,
             srcAddress,
             destAddress,
             amount,

--- a/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
+++ b/packages/solidity/contracts/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.sol
@@ -42,6 +42,16 @@ contract LiquidityPoolBridge is
     /// @notice Mapping of bridge IDs to bridging to remote event data
     mapping(uint256 => BridgeToRemoteData) public bridgesToRemote;
 
+    struct BridgeFromRemoteData {
+        address srcAddress;
+        address destAddress;
+        uint256 amount;
+        address destToken;
+    }
+
+    /// @notice Mapping of bridge IDs to bridging from remote event data
+    mapping(bytes32 => BridgeFromRemoteData) public bridgesFromRemote;
+
     /// @notice Constructor for the LiquidityPoolBridge contract
     /// @param remoteChain_ The identifier for the remote chain
     /// @param token_ The address of the ERC20 representing the asset being bridged
@@ -118,10 +128,12 @@ contract LiquidityPoolBridge is
     /// @param srcAddress The address initiating the bridge
     /// @param destAddress The address receiving the bridged tokens
     /// @param amount The amount of tokens being bridged
+    /// @param nonce The unique identifier for the bridge transaction
     function bridgeFromRemote(
         address srcAddress,
         address destAddress,
-        uint256 amount
+        uint256 amount,
+        bytes32 nonce
     ) external whenNotRetired whenNotPaused onlyOwner {
         if (destAddress == address(0)) {
             revert BridgeAddressZero();
@@ -135,6 +147,14 @@ contract LiquidityPoolBridge is
 
         // Transfer tokens from liquidity source to destination
         token.safeTransferFrom(liquiditySource, destAddress, amount);
+
+        // update mapping
+        bridgesFromRemote[nonce] = BridgeFromRemoteData({
+            srcAddress: srcAddress,
+            destAddress: destAddress,
+            amount: amount,
+            destToken: address(token)
+        });
 
         emit BridgedFromRemote(
             nextBridgeFromId++,

--- a/packages/solidity/test/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.test.ts
+++ b/packages/solidity/test/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.test.ts
@@ -55,6 +55,46 @@ describe('LiquidityPoolBridge', () => {
         .to.be.revertedWith('max=0')
     })
   })
+  describe('properties', () => {
+    it('should only increment bridge ID after successful bridge', async () => {
+      // Arrange
+      const { token } = await loadFixture(deployTestERC20)
+      const tokenAddress = await token.getAddress()
+      const fixture = () => deployLiquidityPoolBridge(tokenAddress, hotWallet.address)
+      const { bridge } = await loadFixture(fixture)
+      const initialBridgeId = await bridge.nextBridgeFromId()
+      const bridgeCount = 5
+      const totalAmount = amount * BigInt(bridgeCount)
+      const reusedNonce = ethers.sha256(ethers.randomBytes(32))
+      await fundHotWallet(token, owner, hotWallet, totalAmount)
+
+      // Act / Assert
+      for (let i = 0; i < bridgeCount; i++) {
+        // approve spend on each iteration
+        await approveHotWallet(token, hotWallet, await bridge.getAddress(), amount)
+        // for first iteration, supply a nonce
+        if (i === 0) {
+          expect(await expectBridgeFromSucceed({
+            bridge, from: owner, hotWallet, to: destination, amount, token, nonce: reusedNonce,
+          }))
+          continue
+        }
+        // for the second iteration, supply a reused nonce and expect failure
+        if (i === 1) {
+          await expect(expectBridgeFromSucceed({
+            bridge, from: owner, hotWallet, to: destination, amount, token, nonce: reusedNonce,
+          })).to.be.revertedWithCustomError(bridge, 'BridgesFromRemoteAlreadyExists')
+          continue
+        }
+        // for subsequent iterations don't reuse a nonce
+        await expectBridgeFromSucceed({
+          bridge, from: owner, hotWallet, to: destination, amount, token,
+        })
+      }
+      // ensure the incrementor only increased for successful bridges
+      expect(await bridge.nextBridgeFromId()).to.equal(initialBridgeId + BigInt(bridgeCount - 1))
+    })
+  })
   describe('bridgeTo', () => {
     describe('when called by owner', () => {
       it('should bridge tokens and emit event', async () => {
@@ -348,44 +388,6 @@ describe('LiquidityPoolBridge', () => {
         await expect(
           bridge.bridgeFromRemote(owner.address, user.address, amount, nonce),
         ).to.be.revertedWithCustomError(bridge, 'BridgesFromRemoteAlreadyExists')
-      })
-      it('should only increment bridge ID after successful bridge', async () => {
-        // Arrange
-        const { token } = await loadFixture(deployTestERC20)
-        const tokenAddress = await token.getAddress()
-        const fixture = () => deployLiquidityPoolBridge(tokenAddress, hotWallet.address)
-        const { bridge } = await loadFixture(fixture)
-        const initialBridgeId = await bridge.nextBridgeFromId()
-        const bridgeCount = 5
-        const totalAmount = amount * BigInt(bridgeCount)
-        const reusedNonce = ethers.sha256(ethers.randomBytes(32))
-        await fundHotWallet(token, owner, hotWallet, totalAmount)
-
-        // Act / Assert
-        for (let i = 0; i < bridgeCount; i++) {
-          // approve spend on each iteration
-          await approveHotWallet(token, hotWallet, await bridge.getAddress(), amount)
-          // for first iteration, supply a nonce
-          if (i === 0) {
-            expect(await expectBridgeFromSucceed({
-              bridge, from: owner, hotWallet, to: destination, amount, token, nonce: reusedNonce,
-            }))
-            continue
-          }
-          // for the second iteration, supply a reused nonce and expect failure
-          if (i === 1) {
-            await expect(expectBridgeFromSucceed({
-              bridge, from: owner, hotWallet, to: destination, amount, token, nonce: reusedNonce,
-            })).to.be.revertedWithCustomError(bridge, 'BridgesFromRemoteAlreadyExists')
-            continue
-          }
-          // for subsequent iterations don't reuse a nonce
-          await expectBridgeFromSucceed({
-            bridge, from: owner, hotWallet, to: destination, amount, token,
-          })
-        }
-        // ensure the incrementor only increased for successful bridges
-        expect(await bridge.nextBridgeFromId()).to.equal(initialBridgeId + BigInt(bridgeCount - 1))
       })
     })
     describe('when called by non-owner', () => {

--- a/packages/solidity/test/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.test.ts
+++ b/packages/solidity/test/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.test.ts
@@ -55,46 +55,6 @@ describe('LiquidityPoolBridge', () => {
         .to.be.revertedWith('max=0')
     })
   })
-  describe('properties', () => {
-    it('should only increment bridge ID after successful bridge', async () => {
-      // Arrange
-      const { token } = await loadFixture(deployTestERC20)
-      const tokenAddress = await token.getAddress()
-      const fixture = () => deployLiquidityPoolBridge(tokenAddress, hotWallet.address)
-      const { bridge } = await loadFixture(fixture)
-      const initialBridgeId = await bridge.nextBridgeFromId()
-      const bridgeCount = 5
-      const totalAmount = amount * BigInt(bridgeCount)
-      const reusedNonce = ethers.sha256(ethers.randomBytes(32))
-      await fundHotWallet(token, owner, hotWallet, totalAmount)
-
-      // Act / Assert
-      for (let i = 0; i < bridgeCount; i++) {
-        // approve spend on each iteration
-        await approveHotWallet(token, hotWallet, await bridge.getAddress(), amount)
-        // for first iteration, supply a nonce
-        if (i === 0) {
-          expect(await expectBridgeFromSucceed({
-            bridge, from: owner, hotWallet, to: destination, amount, token, nonce: reusedNonce,
-          }))
-          continue
-        }
-        // for the second iteration, supply a reused nonce and expect failure
-        if (i === 1) {
-          await expect(expectBridgeFromSucceed({
-            bridge, from: owner, hotWallet, to: destination, amount, token, nonce: reusedNonce,
-          })).to.be.revertedWithCustomError(bridge, 'BridgesFromRemoteAlreadyExists')
-          continue
-        }
-        // for subsequent iterations don't reuse a nonce
-        await expectBridgeFromSucceed({
-          bridge, from: owner, hotWallet, to: destination, amount, token,
-        })
-      }
-      // ensure the incrementor only increased for successful bridges
-      expect(await bridge.nextBridgeFromId()).to.equal(initialBridgeId + BigInt(bridgeCount - 1))
-    })
-  })
   describe('bridgeTo', () => {
     describe('when called by owner', () => {
       it('should bridge tokens and emit event', async () => {
@@ -388,6 +348,37 @@ describe('LiquidityPoolBridge', () => {
         await expect(
           bridge.bridgeFromRemote(owner.address, user.address, amount, nonce),
         ).to.be.revertedWithCustomError(bridge, 'BridgesFromRemoteAlreadyExists')
+      })
+      it('should only increment bridge ID after successful bridge', async () => {
+      // Arrange
+        const { token } = await loadFixture(deployTestERC20)
+        const tokenAddress = await token.getAddress()
+        const fixture = () => deployLiquidityPoolBridge(tokenAddress, hotWallet.address)
+        const { bridge } = await loadFixture(fixture)
+        const initialBridgeId = await bridge.nextBridgeFromId()
+        const reusedNonce = ethers.sha256(ethers.randomBytes(32))
+        const totalAttempts = 3
+        await fundHotWallet(token, owner, hotWallet, amount * BigInt(totalAttempts))
+
+        // Act / Assert
+        // first attempt successful
+        await approveHotWallet(token, hotWallet, await bridge.getAddress(), amount)
+        expect(await expectBridgeFromSucceed({
+          bridge, from: owner, hotWallet, to: destination, amount, token, nonce: reusedNonce,
+        }))
+        // second attempt fails
+        await approveHotWallet(token, hotWallet, await bridge.getAddress(), amount)
+        await expect(expectBridgeFromSucceed({
+          bridge, from: owner, hotWallet, to: destination, amount, token, nonce: reusedNonce,
+        })).to.be.revertedWithCustomError(bridge, 'BridgesFromRemoteAlreadyExists')
+        // third attempt successful
+        await approveHotWallet(token, hotWallet, await bridge.getAddress(), amount)
+        expect(await expectBridgeFromSucceed({
+          bridge, from: owner, hotWallet, to: destination, amount, token,
+        }))
+        // ensure the incrementor only increased for successful bridges
+        const successfulAttempts = 2n
+        expect(await bridge.nextBridgeFromId()).to.equal(initialBridgeId + successfulAttempts)
       })
     })
     describe('when called by non-owner', () => {

--- a/packages/solidity/test/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.test.ts
+++ b/packages/solidity/test/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.test.ts
@@ -13,7 +13,7 @@ import {
 
 const { ethers } = hre
 
-describe.only('LiquidityPoolBridge', () => {
+describe('LiquidityPoolBridge', () => {
   const amount = ethers.parseUnits('1000000', 18)
 
   let owner: HardhatEthersSigner

--- a/packages/solidity/test/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.test.ts
+++ b/packages/solidity/test/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.test.ts
@@ -13,7 +13,7 @@ import {
 
 const { ethers } = hre
 
-describe('LiquidityPoolBridge', () => {
+describe.only('LiquidityPoolBridge', () => {
   const amount = ethers.parseUnits('1000000', 18)
 
   let owner: HardhatEthersSigner

--- a/packages/solidity/test/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.test.ts
+++ b/packages/solidity/test/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.test.ts
@@ -349,6 +349,44 @@ describe('LiquidityPoolBridge', () => {
           bridge.bridgeFromRemote(owner.address, user.address, amount, nonce),
         ).to.be.revertedWithCustomError(bridge, 'BridgesFromRemoteAlreadyExists')
       })
+      it('should only increment bridge ID after successful bridge', async () => {
+        // Arrange
+        const { token } = await loadFixture(deployTestERC20)
+        const tokenAddress = await token.getAddress()
+        const fixture = () => deployLiquidityPoolBridge(tokenAddress, hotWallet.address)
+        const { bridge } = await loadFixture(fixture)
+        const initialBridgeId = await bridge.nextBridgeFromId()
+        const bridgeCount = 5
+        const totalAmount = amount * BigInt(bridgeCount)
+        const reusedNonce = ethers.sha256(ethers.randomBytes(32))
+        await fundHotWallet(token, owner, hotWallet, totalAmount)
+
+        // Act / Assert
+        for (let i = 0; i < bridgeCount; i++) {
+          // approve spend on each iteration
+          await approveHotWallet(token, hotWallet, await bridge.getAddress(), amount)
+          // for first iteration, supply a nonce
+          if (i === 0) {
+            expect(await expectBridgeFromSucceed({
+              bridge, from: owner, hotWallet, to: destination, amount, token, nonce: reusedNonce,
+            }))
+            continue
+          }
+          // for the second iteration, supply a reused nonce and expect failure
+          if (i === 1) {
+            await expect(expectBridgeFromSucceed({
+              bridge, from: owner, hotWallet, to: destination, amount, token, nonce: reusedNonce,
+            })).to.be.revertedWithCustomError(bridge, 'BridgesFromRemoteAlreadyExists')
+            continue
+          }
+          // for subsequent iterations don't reuse a nonce
+          await expectBridgeFromSucceed({
+            bridge, from: owner, hotWallet, to: destination, amount, token,
+          })
+        }
+        // ensure the incrementor only increased for successful bridges
+        expect(await bridge.nextBridgeFromId()).to.equal(initialBridgeId + BigInt(bridgeCount - 1))
+      })
     })
     describe('when called by non-owner', () => {
       it('should fail because non-owners cannot bridge from remote', async () => {

--- a/packages/solidity/test/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.test.ts
+++ b/packages/solidity/test/xyo-chain/LiquidityPoolBridge/LiquidityPoolBridge.test.ts
@@ -331,6 +331,24 @@ describe('LiquidityPoolBridge', () => {
           bridge, from: owner, hotWallet, to: ZeroAddress, amount, token,
         })).to.be.revertedWithCustomError(bridge, 'BridgeAddressZero')
       })
+      it('should revert if trying to bridge with duplicate nonce', async () => {
+        // Arrange
+        const { token } = await loadFixture(deployTestERC20)
+        const tokenAddress = await token.getAddress()
+        const fixture = () => deployLiquidityPoolBridge(tokenAddress, hotWallet.address)
+        const { bridge } = await loadFixture(fixture)
+        await fundHotWallet(token, owner, hotWallet, amount)
+        await approveHotWallet(token, hotWallet, await bridge.getAddress(), amount)
+
+        // Act / Assert
+        // Update the bridgesFromRemote mapping by calling bridgeFromRemote (owner only)
+        const nonce = ethers.sha256(ethers.randomBytes(32))
+        await bridge.bridgeFromRemote(owner.address, user.address, amount, nonce)
+
+        await expect(
+          bridge.bridgeFromRemote(owner.address, user.address, amount, nonce),
+        ).to.be.revertedWithCustomError(bridge, 'BridgesFromRemoteAlreadyExists')
+      })
     })
     describe('when called by non-owner', () => {
       it('should fail because non-owners cannot bridge from remote', async () => {

--- a/packages/solidity/test/xyo-chain/helpers/liquidityPoolBridgeHelpers.ts
+++ b/packages/solidity/test/xyo-chain/helpers/liquidityPoolBridgeHelpers.ts
@@ -1,5 +1,6 @@
 import type { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers'
 import { assertEx } from '@xylabs/assert'
+import { isDefined } from '@xylabs/typeof'
 import { expect } from 'chai'
 import { type AddressLike, ethers } from 'ethers'
 
@@ -36,7 +37,7 @@ export const expectBridgeFromSucceed = async ({
   const initialBalance = await token.balanceOf(hotWallet.address)
 
   // random sha256 hash for nonce
-  nonce = ethers.sha256(ethers.randomBytes(32))
+  nonce = isDefined(nonce) ? nonce : ethers.sha256(ethers.randomBytes(32))
 
   // Send tokens to bridge
   const tx = await bridge.connect(from).bridgeFromRemote(from.address, to, amount, nonce)

--- a/packages/solidity/test/xyo-chain/helpers/liquidityPoolBridgeHelpers.ts
+++ b/packages/solidity/test/xyo-chain/helpers/liquidityPoolBridgeHelpers.ts
@@ -22,12 +22,13 @@ export const fundHotWallet = async (
 }
 
 export const expectBridgeFromSucceed = async ({
-  bridge, from, to, amount, token, hotWallet,
+  bridge, from, to, amount, token, hotWallet, nonce,
 }: {
   amount: bigint
   bridge: LiquidityPoolBridge
   from: HardhatEthersSigner
   hotWallet: HardhatEthersSigner
+  nonce?: string
   to: AddressLike
   token: BridgeableToken
 }) => {
@@ -35,7 +36,7 @@ export const expectBridgeFromSucceed = async ({
   const initialBalance = await token.balanceOf(hotWallet.address)
 
   // random sha256 hash for nonce
-  const nonce = ethers.sha256(ethers.randomBytes(32))
+  nonce = ethers.sha256(ethers.randomBytes(32))
 
   // Send tokens to bridge
   const tx = await bridge.connect(from).bridgeFromRemote(from.address, to, amount, nonce)

--- a/packages/solidity/test/xyo-chain/helpers/liquidityPoolBridgeHelpers.ts
+++ b/packages/solidity/test/xyo-chain/helpers/liquidityPoolBridgeHelpers.ts
@@ -1,7 +1,7 @@
 import type { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers'
 import { assertEx } from '@xylabs/assert'
 import { expect } from 'chai'
-import type { AddressLike } from 'ethers'
+import { type AddressLike, ethers } from 'ethers'
 
 import type { BridgeableToken, LiquidityPoolBridge } from '../../../typechain-types'
 
@@ -31,11 +31,13 @@ export const expectBridgeFromSucceed = async ({
   to: AddressLike
   token: BridgeableToken
 }) => {
-  const nextBridgeId = await bridge.nextBridgeFromId()
   const initialBalance = await token.balanceOf(hotWallet.address)
 
+  // random sha256 hash for nonce
+  const nonce = ethers.sha256(ethers.randomBytes(32))
+
   // Send tokens to bridge
-  const tx = await bridge.connect(from).bridgeFromRemote(from.address, to, amount)
+  const tx = await bridge.connect(from).bridgeFromRemote(from.address, to, amount, nonce)
   const receipt = await tx.wait()
   expect(receipt).not.to.equal(null)
 
@@ -45,7 +47,7 @@ export const expectBridgeFromSucceed = async ({
   const log = logs.at(-1)
   expect(log).not.to.equal(undefined)
   const event = assertEx(log)
-  expect(event?.args.id).to.equal(nextBridgeId)
+  expect(event?.args.id).to.equal(nonce)
   expect(event?.args.srcAddress).to.equal(from.address)
   expect(event?.args.destAddress).to.equal(to)
   expect(event?.args.amount).to.equal(amount)

--- a/packages/solidity/test/xyo-chain/helpers/liquidityPoolBridgeHelpers.ts
+++ b/packages/solidity/test/xyo-chain/helpers/liquidityPoolBridgeHelpers.ts
@@ -31,6 +31,7 @@ export const expectBridgeFromSucceed = async ({
   to: AddressLike
   token: BridgeableToken
 }) => {
+  const nextBridgeFromId = await bridge.nextBridgeFromId()
   const initialBalance = await token.balanceOf(hotWallet.address)
 
   // random sha256 hash for nonce
@@ -47,10 +48,22 @@ export const expectBridgeFromSucceed = async ({
   const log = logs.at(-1)
   expect(log).not.to.equal(undefined)
   const event = assertEx(log)
+
+  // test counter increment
+  expect(await bridge.nextBridgeFromId()).to.equal(nextBridgeFromId + 1n)
+
+  // test event args match expected values
   expect(event?.args.id).to.equal(nonce)
   expect(event?.args.srcAddress).to.equal(from.address)
   expect(event?.args.destAddress).to.equal(to)
   expect(event?.args.amount).to.equal(amount)
+
+  // test mapping entry matches expected values
+  const newMapEntry = await bridge.bridgesFromRemote(nonce)
+  expect(newMapEntry.srcAddress).to.equal(from.address)
+  expect(newMapEntry.destAddress).to.equal(to)
+  expect(newMapEntry.amount).to.equal(amount)
+  expect(newMapEntry.destToken).to.equal(await token.getAddress())
 
   const finalBalance = await token.balanceOf(hotWallet.address)
   expect(finalBalance).to.equal(initialBalance - amount)
@@ -84,10 +97,23 @@ export const expectBridgeToSucceed = async ({
   const log = logs.at(-1)
   expect(log).not.to.equal(undefined)
   const event = assertEx(log)
+
+  // test counter increment
+  expect(await bridge.nextBridgeToId()).to.equal(nextBridgeId + 1n)
+
+  // test event args match expected values
   expect(event?.args.id).to.equal(nextBridgeId)
   expect(event?.args.srcAddress).to.equal(from.address)
   expect(event?.args.destAddress).to.equal(to)
   expect(event?.args.amount).to.equal(amount)
+  expect(event?.args.destToken).to.equal(await bridge.remoteChain())
+
+  // test mapping entry matches expected values
+  const newMapEntry = await bridge.bridgesToRemote(nextBridgeId)
+  expect(newMapEntry.srcAddress).to.equal(from.address)
+  expect(newMapEntry.destAddress).to.equal(to)
+  expect(newMapEntry.amount).to.equal(amount)
+  expect(newMapEntry.destToken).to.equal(await token.getAddress())
 
   const finalBalance = await token.balanceOf(from.address)
   expect(finalBalance).to.equal(initialBalance - amount)

--- a/packages/solidity/test/xyo-chain/helpers/liquidityPoolBridgeHelpers.ts
+++ b/packages/solidity/test/xyo-chain/helpers/liquidityPoolBridgeHelpers.ts
@@ -52,7 +52,8 @@ export const expectBridgeFromSucceed = async ({
   const event = assertEx(log)
 
   // test counter increment
-  expect(await bridge.nextBridgeFromId()).to.equal(nextBridgeFromId + 1n)
+  const newBridgeFromId = await bridge.nextBridgeFromId()
+  expect(newBridgeFromId).to.equal(nextBridgeFromId + 1n)
 
   // test event args match expected values
   expect(event?.args.id).to.equal(nonce)
@@ -101,17 +102,18 @@ export const expectBridgeToSucceed = async ({
   const event = assertEx(log)
 
   // test counter increment
-  expect(await bridge.nextBridgeToId()).to.equal(nextBridgeId + 1n)
+  const newNextBridgeToId = await bridge.nextBridgeToId()
+  expect(newNextBridgeToId).to.equal(nextBridgeId + 1n)
 
   // test event args match expected values
-  expect(event?.args.id).to.equal(nextBridgeId)
+  expect(event?.args.id).to.equal(newNextBridgeToId)
   expect(event?.args.srcAddress).to.equal(from.address)
   expect(event?.args.destAddress).to.equal(to)
   expect(event?.args.amount).to.equal(amount)
   expect(event?.args.destToken).to.equal(await bridge.remoteChain())
 
   // test mapping entry matches expected values
-  const newMapEntry = await bridge.bridgesToRemote(nextBridgeId)
+  const newMapEntry = await bridge.bridgesToRemote(newNextBridgeToId)
   expect(newMapEntry.srcAddress).to.equal(from.address)
   expect(newMapEntry.destAddress).to.equal(to)
   expect(newMapEntry.amount).to.equal(amount)


### PR DESCRIPTION
Adds mappings to track bridge attempts and includes a nonce in the `BridgedFromRemote` event for better identification of bridging transactions.

- Introduces `bridgesToRemote` and `bridgesFromRemote` mappings to store data related to bridging events.
- Includes a nonce in the `BridgedFromRemote` event to uniquely identify bridge transactions.
- Updates tests to ensure correct counter increments, event arguments, and mapping entries.